### PR TITLE
RDI-3232 gmain: emscripten: Use 0 timeout

### DIFF
--- a/glib/gmain.c
+++ b/glib/gmain.c
@@ -4271,7 +4271,9 @@ g_main_context_iterate (GMainContext *context,
       UNLOCK_CONTEXT (context);
     }
 
+#ifndef G_WITH_EMSCRIPTEN
   if (!block)
+#endif
     timeout = 0;
   
   g_main_context_poll (context, timeout, max_priority, fds, nfds);


### PR DESCRIPTION
As of the date non-zero timeouts are not supported on poll()